### PR TITLE
Add epoch_stake

### DIFF
--- a/schema/tables/epoch_stake.json
+++ b/schema/tables/epoch_stake.json
@@ -1,0 +1,26 @@
+[
+  {
+    "description": "The epoch number.",
+    "name": "epoch_no",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The hash identifier of the stake address.",
+    "name": "stake_addr_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The hash of the pool that this entry is delegated to.",
+    "name": "pool_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The amount (in Lovelace) being staked.",
+    "name": "amount",
+    "type": "NUMERIC",
+    "mode": "REQUIRED"
+  }
+]

--- a/schema/views/vw_bq_epoch_stake.sql
+++ b/schema/views/vw_bq_epoch_stake.sql
@@ -1,0 +1,20 @@
+-- View: analytics.vw_bq_epoch_stake
+
+-- DROP VIEW analytics.vw_bq_epoch_stake;
+
+CREATE OR REPLACE VIEW analytics.vw_bq_epoch_stake
+AS
+SELECT es.epoch_no,
+       encode(sa.hash_raw, 'hex') AS stake_addr_hash,
+       encode(ph.hash_raw, 'hex') AS pool_hash,
+       es.amount
+FROM public.epoch_stake es
+         JOIN public.stake_address sa ON es.addr_id = sa.id
+         JOIN public.pool_hash ph ON es.pool_id = ph.id
+ORDER BY epoch_no, stake_addr_hash, pool_hash ASC;
+
+ALTER TABLE analytics.vw_bq_epoch_stake
+    OWNER TO cardano;
+
+GRANT SELECT ON TABLE analytics.vw_bq_epoch_stake TO PUBLIC;
+GRANT ALL ON TABLE analytics.vw_bq_epoch_stake TO cardano;

--- a/scripts/deep_compare/epoch_tables.py
+++ b/scripts/deep_compare/epoch_tables.py
@@ -4,7 +4,9 @@ import pandas as pd
 def query_epoch_tables(epoch_no):
     return [
             query_epoch_param(epoch_no),
-            query_param_proposal(epoch_no)
+            query_param_proposal(epoch_no),
+            query_ada_pots(epoch_no),
+            query_epoch_stake(epoch_no)
     ]
 
 
@@ -158,4 +160,57 @@ def query_param_proposal(epoch_no):
                        ||',' || (registered_tx_index)  
                        ||')' AS str
                       FROM analytics.vw_bq_param_proposal WHERE epoch_no = {epoch_no}) AS subq""",
+            lambda x: x, lambda x: x)
+
+
+def query_ada_pots(epoch_no):
+    return (f"""SELECT TO_BASE64(SHA256(innerq.str)) AS hash_b64 FROM
+                 (SELECT
+                    '('|| (epoch_no)
+                       ||',' || (slot_no)
+                       ||',' || (treasury)
+                       ||',' || (reserves)
+                       ||',' || (rewards)
+                       ||',' || (utxo)
+                       ||',' || (deposits)
+                       ||',' || (fees)
+                       ||')' AS str
+                  FROM cardano_mainnet.ada_pots
+                  WHERE epoch_no = {epoch_no}
+                ) AS innerq;""",
+            f"""SELECT encode(SHA256(subq.str::bytea),'base64') AS hash_b64 FROM
+                    (SELECT 
+                    '('|| (epoch_no)
+                       ||',' || (slot_no)
+                       ||',' || (treasury)
+                       ||',' || (reserves)
+                       ||',' || (rewards)
+                       ||',' || (utxo)
+                       ||',' || (deposits)
+                       ||',' || (fees)
+                       ||')' AS str
+                      FROM public.ada_pots WHERE epoch_no = {epoch_no}) AS subq""",
+            lambda x: x, lambda x: x)
+
+
+def query_epoch_stake(epoch_no):
+    return (f"""SELECT TO_BASE64(SHA256(innerq.str)) AS hash_b64 FROM
+                 (SELECT
+                    '('|| (epoch_no)
+                       ||',' || (stake_addr_hash)
+                       ||',' || (pool_hash)
+                       ||',' || (amount)
+                       ||')' AS str
+                  FROM cardano_mainnet.epoch_stake
+                  WHERE epoch_no = {epoch_no}
+                  ORDER BY epoch_no, stake_addr_hash, pool_hash ASC
+                ) AS innerq;""",
+            f"""SELECT encode(SHA256(subq.str::bytea),'base64') AS hash_b64 FROM
+                    (SELECT 
+                    '('|| (epoch_no)
+                       ||',' || (stake_addr_hash)
+                       ||',' || (pool_hash)
+                       ||',' || (amount)
+                       ||')' AS str
+                      FROM analytics.vw_bq_epoch_stake WHERE epoch_no = {epoch_no}) AS subq""",
             lambda x: x, lambda x: x)

--- a/scripts/export_epoch_stake.sh
+++ b/scripts/export_epoch_stake.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+source config.pg
+source functions.sh
+
+function Q() {
+      local EPOCH=$1
+      echo "
+  SELECT epoch_no,
+         stake_addr_hash,
+         pool_hash,
+         amount
+  FROM analytics.vw_bq_epoch_stake
+  WHERE epoch_no = ${EPOCH}
+        "
+}
+
+# epoch_stake started in epoch 210
+process_epoch_f Q "epoch_stake" "iog-data-analytics.db_sync" 210

--- a/scripts/export_epoch_stake.sh
+++ b/scripts/export_epoch_stake.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-source config.pg
+source ./conf/config.bq
+source ./conf/config.pg
 source functions.sh
 
 function Q() {
@@ -18,4 +19,4 @@ function Q() {
 }
 
 # epoch_stake started in epoch 210
-process_epoch_f Q "epoch_stake" "iog-data-analytics.db_sync" 210
+process_epoch_f Q "epoch_stake" "${BQ_PROJECT}.db_sync" 210

--- a/scripts/run_bq_pg_compare.sh
+++ b/scripts/run_bq_pg_compare.sh
@@ -20,12 +20,13 @@ ${BQ} ls
 declare -a TablesPerEpoch=(
 		"delegation"
 		"epoch_param"
+		"epoch_stake"
 		"ada_pots"
 		"ma_minting"
 		"param_proposal"
 		"pool_offline_data"
 		"pool_update"
-                "rel_addr_txout"
+    "rel_addr_txout"
 		"rel_stake_txout"
 		"reward"
 	   )

--- a/scripts/run_bq_pg_compare.sh
+++ b/scripts/run_bq_pg_compare.sh
@@ -26,7 +26,7 @@ declare -a TablesPerEpoch=(
 		"param_proposal"
 		"pool_offline_data"
 		"pool_update"
-    "rel_addr_txout"
+                "rel_addr_txout"
 		"rel_stake_txout"
 		"reward"
 	   )

--- a/scripts/run_update_epoch.sh
+++ b/scripts/run_update_epoch.sh
@@ -21,7 +21,7 @@ echo $BQ_CONFIG > ${TEMPDIR}/key.json
 gcloud auth activate-service-account $BQUSER --key-file ${TEMPDIR}/key.json 
 ${BQ} ls
 
-declare -a Tables=("epoch_param" "ada_pots" "param_proposal" "ma_minting" "pool_update" "pool_offline_data" "delegation" "reward" "rel_addr_txout" "rel_stake_txout" )
+declare -a Tables=("epoch_param" "ada_pots" "param_proposal" "ma_minting" "pool_update" "pool_offline_data" "delegation" "reward" "rel_addr_txout" "rel_stake_txout" "epoch_stake" )
  
 # use for loop to read all tables
 for (( i=0; i<${#Tables[@]}; i++ ));

--- a/scripts/update_epoch_epoch_stake.sh
+++ b/scripts/update_epoch_epoch_stake.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+if [ $# -lt 2 ]; then
+	echo "$0 bq_epoch_no pg_epoch_no"
+	exit 1
+fi
+
+set -e
+
+source config.pg
+source functions.sh
+
+TNAME="epoch_stake"
+
+BQ_EPOCH_NO=$1
+PG_EPOCH_NO=$2
+
+if [ "$BQ_EPOCH_NO" -eq "$PG_EPOCH_NO" ]; then
+	echo "Last epoch in BigQuery is $BQ_EPOCH_NO. Nothing to do."
+	exit 1
+elif [ "$BQ_EPOCH_NO" -gt "$PG_EPOCH_NO" ]; then
+  echo "Last epoch in BigQuery is $BQ_EPOCH_NO > $PG_EPOCH_NO (epoch in Postgres)"
+  exit 1
+else 
+  EPOCH_NO=$(( BQ_EPOCH_NO + 1 ))
+  echo "BQ @ ${EPOCH_NO}"
+  echo "   loading for epoch $EPOCH_NO"
+fi
+
+CSVNAME="update_epoch_stake-q1"
+if [ -e "${CSVNAME}.csv" ]; then rm -f "${CSVNAME}.csv"; fi
+SCHEMA="epoch_stake"
+DATASETID="iog-data-analytics:db_sync"
+
+## 1 insert epoch into table: tmp_epoch_stake_1
+TMPTBL="tmp_epoch_stake_1"
+Q="
+  SELECT epoch_no,
+         stake_addr_hash,
+         pool_hash,
+         amount
+  FROM analytics.vw_bq_epoch_stake
+  WHERE epoch_no = ${EPOCH_NO}"
+NREAD=$(pg_query_to_csv "${Q}" "$CSVNAME")
+
+TARGETTBL="iog-data-analytics.cardano_mainnet.${TNAME}"
+
+#DRYRUN="--dry_run"
+DRYRUN=
+
+if [ -z "${NREAD}" -o $NREAD -lt 0 ]
+then 
+  echo "Q: returned ${NREAD}."; 
+  exit 1;
+elif [ $NREAD -eq 0 ]
+then
+  echo "Q: returned ${NREAD}. Updating last index."; 
+  Q="
+   -- update the last index table
+   UPDATE db_sync.last_index set last_epoch_no=${EPOCH_NO} WHERE tablename='${TARGETTBL}';"
+  ${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query1.err > logs/update_${TNAME}-query1.out
+  echo "index updated to epoch: ${EPOCH_NO}"
+  exit 0;
+fi
+bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
+
+# run the transaction
+SRCDATASET="iog-data-analytics.db_sync"
+Q="
+   BEGIN TRANSACTION;
+   -- 1 insert new epoch
+   INSERT INTO ${TARGETTBL}
+   SELECT * FROM ${SRCDATASET}.${TMPTBL};
+   -- 2 update the last index table
+   UPDATE db_sync.last_index set last_epoch_no=${EPOCH_NO} WHERE tablename='${TARGETTBL}';
+   COMMIT TRANSACTION;
+"
+
+${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query2.err > logs/update_${TNAME}-query2.out
+
+echo
+echo "values inserted successfully for epoch: ${EPOCH_NO}"
+echo "all done."

--- a/scripts/update_epoch_epoch_stake.sh
+++ b/scripts/update_epoch_epoch_stake.sh
@@ -7,7 +7,7 @@ fi
 
 set -e
 
-source config.pg
+source ./config/config.pg
 source functions.sh
 
 TNAME="epoch_stake"
@@ -30,7 +30,7 @@ fi
 CSVNAME="update_epoch_stake-q1"
 if [ -e "${CSVNAME}.csv" ]; then rm -f "${CSVNAME}.csv"; fi
 SCHEMA="epoch_stake"
-DATASETID="iog-data-analytics:db_sync"
+DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into table: tmp_epoch_stake_1
 TMPTBL="tmp_epoch_stake_1"
@@ -43,7 +43,7 @@ Q="
   WHERE epoch_no = ${EPOCH_NO}"
 NREAD=$(pg_query_to_csv "${Q}" "$CSVNAME")
 
-TARGETTBL="iog-data-analytics.cardano_mainnet.${TNAME}"
+TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 
 #DRYRUN="--dry_run"
 DRYRUN=
@@ -65,7 +65,7 @@ fi
 bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 
 # run the transaction
-SRCDATASET="iog-data-analytics.db_sync"
+SRCDATASET="${BQ_PROJECT}.db_sync"
 Q="
    BEGIN TRANSACTION;
    -- 1 insert new epoch

--- a/scripts/update_epoch_epoch_stake.sh
+++ b/scripts/update_epoch_epoch_stake.sh
@@ -7,7 +7,7 @@ fi
 
 set -e
 
-source ./config/config.pg
+source ./conf/config.pg
 source functions.sh
 
 TNAME="epoch_stake"


### PR DESCRIPTION
Add the scripts required for the epoch_stake.
Added also the deep comparison for `ada_pots`
The deep comparison has been run successfully until epoch 415.

I'm currently running the export from epoch 416.
The current branch has been checked out in folder `/tmp` in server bca2 and runs in the tmux session: `backfill`

