### PR TITLE
Create a one big transaction

### DIFF
--- a/scripts/run_bq_update.sh
+++ b/scripts/run_bq_update.sh
@@ -32,7 +32,7 @@ for TABLE in tx tx_in_out tx_consumed_output tx_hash tx_metadata block block_has
   SCRIPT="./update_${TABLE}.sh"
   echo "Updating ${TABLENAME} since ${STARTING_SLOT} slot until ${ENDING_SLOT}"
   $(${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT})
-  OUTPUT=$(cat "/tmp/${TABLE}-query.sql)
+  OUTPUT=$(cat "/tmp/${TABLE}-query.sql")
   # Append the script output to the Q string
   Q+="${OUTPUT}\n"
   rm "/tmp/${TABLE}-query.sql"

--- a/scripts/run_bq_update.sh
+++ b/scripts/run_bq_update.sh
@@ -31,7 +31,7 @@ for TABLE in tx tx_in_out tx_consumed_output tx_hash tx_metadata block block_has
 
   SCRIPT="./update_${TABLE}.sh"
   echo "Updating ${TABLENAME} since ${STARTING_SLOT} slot until ${ENDING_SLOT}"
-  $(${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT})
+  ${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT}
   OUTPUT=$(cat "/tmp/${TABLE}-query.sql")
   # Append the script output to the Q string
   Q+="${OUTPUT}\n"

--- a/scripts/run_bq_update.sh
+++ b/scripts/run_bq_update.sh
@@ -31,9 +31,11 @@ for TABLE in tx tx_in_out tx_consumed_output tx_hash tx_metadata block block_has
 
   SCRIPT="./update_${TABLE}.sh"
   echo "Updating ${TABLENAME} since ${STARTING_SLOT} slot until ${ENDING_SLOT}"
-  OUTPUT=$(${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT})  # Capture script output
+  $(${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT})
+  OUTPUT=$(cat "/tmp/${TABLE}-query.sql)
   # Append the script output to the Q string
   Q+="${OUTPUT}\n"
+  rm "/tmp/${TABLE}-query.sql"
 done
 Q+="COMMIT TRANSACTION;"
 # Print the query for debugging (optional)

--- a/scripts/run_bq_update.sh
+++ b/scripts/run_bq_update.sh
@@ -21,23 +21,27 @@ ENDING_SLOT=$(echo ${res2} | ${SED} -ne 's/^max_slot | max_epoch --*+--* \([0-9]
 PG_EPOCH=$(echo ${res2} | ${SED} -ne 's/^max_slot | max_epoch --*+--* \([0-9][0-9]*\) | \([0-9][0-9]*\).*/\2/p;')
 ENDING_SLOT_MINUS_GRACE=$((ENDING_SLOT - GRACE_SLOTS))
 
+Q="BEGIN TRANSACTION;\n"
+
 for TABLE in tx tx_in_out tx_consumed_output tx_hash tx_metadata block block_hash rel_addr_txout rel_stake_txout rel_stake_hash collateral ma_minting script pool_offline_data pool_owner pool_retire pool_update redeemer stake_registration stake_deregistration withdrawal delegation datum; do
   TABLENAME="${BQ_PROJECT}.cardano_mainnet.${TABLE}"
   echo $TABLENAME
   res=$(${BQ} --format=json query --nouse_legacy_sql "SELECT last_slot_no FROM ${BQ_PROJECT}.db_sync.last_index where tablename = '${TABLENAME}'")
   STARTING_SLOT=$(echo ${res} | jq -r '.[0].last_slot_no')
-  COUNT=0
-  while [ "$COUNT" -lt 3 ] && [ "$STARTING_SLOT" -lt "$ENDING_SLOT_MINUS_GRACE" ]
-  do
-    STARTING_SLOT=$(echo ${res} | jq -r '.[0].last_slot_no')
-    SCRIPT="./update_${TABLE}.sh"
-    echo "Updating ${TABLENAME} since ${STARTING_SLOT} slot until ${ENDING_SLOT}"
-    ${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT}
-    res=$(${BQ} --format=json query --nouse_legacy_sql "SELECT last_slot_no FROM ${BQ_PROJECT}.db_sync.last_index where tablename = '${TABLENAME}'")
-    STARTING_SLOT=$(echo ${res} | jq -r '.[0].last_slot_no')
-    COUNT=$((COUNT + 1))
-  done
+
+  SCRIPT="./update_${TABLE}.sh"
+  echo "Updating ${TABLENAME} since ${STARTING_SLOT} slot until ${ENDING_SLOT}"
+  OUTPUT=$(${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT})  # Capture script output
+  # Append the script output to the Q string
+  Q+="${OUTPUT}\n"
 done
+Q+="COMMIT TRANSACTION;"
+# Print the query for debugging (optional)
+# echo -e "$Q"
+
+# Execute the transaction
+${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/transaction-query.err > logs/transaction-query.out
+
 
 echo "Updating db-sync slot_no to ${ENDING_SLOT} and epoch_no to ${PG_EPOCH} in BigQuery"
 Q="UPDATE ${BQ_PROJECT}.db_sync.last_index set last_slot_no=${ENDING_SLOT}, last_epoch_no=${PG_EPOCH} WHERE tablename='db-sync';"

--- a/scripts/run_bq_update.sh
+++ b/scripts/run_bq_update.sh
@@ -32,10 +32,14 @@ for TABLE in tx tx_in_out tx_consumed_output tx_hash tx_metadata block block_has
   SCRIPT="./update_${TABLE}.sh"
   echo "Updating ${TABLENAME} since ${STARTING_SLOT} slot until ${ENDING_SLOT}"
   ${SCRIPT} ${STARTING_SLOT} ${ENDING_SLOT}
-  OUTPUT=$(cat "/tmp/${TABLE}-query.sql")
-  # Append the script output to the Q string
-  Q+="${OUTPUT}\n"
-  rm "/tmp/${TABLE}-query.sql"
+  if [ -f "/tmp/${TABLE}-query.sql" ]; then
+    OUTPUT=$(cat "/tmp/${TABLE}-query.sql")
+    # Append the script output to the Q string
+    Q+="${OUTPUT}\n"
+    rm "/tmp/${TABLE}-query.sql"
+  else
+    echo "File /tmp/${TABLE}-query.sql does not exist. Skipping."
+  fi
 done
 Q+="COMMIT TRANSACTION;"
 # Print the query for debugging (optional)

--- a/scripts/run_bq_update.sh
+++ b/scripts/run_bq_update.sh
@@ -39,6 +39,9 @@ Q+="COMMIT TRANSACTION;"
 # Print the query for debugging (optional)
 # echo -e "$Q"
 
+# DRYRUN="--dry_run"
+DRYRUN=
+
 # Execute the transaction
 ${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/transaction-query.err > logs/transaction-query.out
 

--- a/scripts/update_block.sh
+++ b/scripts/update_block.sh
@@ -66,4 +66,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_block.sh
+++ b/scripts/update_block.sh
@@ -43,7 +43,7 @@ DATASETID="${BQ_PROJECT}:db_sync"
 ## 1 delete slots 
 
 ## 2 insert slots (clean until max) into table: tmp_block_1
-TMPTBL="tmp_block_1"
+TMPTBL="tmp_${SCHEMA}_1"
 Q="
   SELECT epoch_no, slot_no, block_time, block_size, tx_count, sum_tx_fee, script_count, sum_script_size, pool_hash, block_hash
   FROM analytics.vw_bq_block
@@ -58,7 +58,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.block"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -66,14 +65,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_block-query.err > logs/update_block-query.out
-
-echo
-echo "the new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_block_hash.sh
+++ b/scripts/update_block_hash.sh
@@ -43,7 +43,7 @@ DATASETID="${BQ_PROJECT}:db_sync"
 ## 1 delete slots 
 
 ## 2 insert slots (clean until max) into table: tmp_block_hash_1
-TMPTBL="tmp_block_hash_1"
+TMPTBL="tmp_${SCHEMA}_1"
 Q="
 SELECT epoch_no, slot_no, block_hash
   FROM analytics.vw_bq_block_hash
@@ -58,7 +58,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.block_hash"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -66,14 +65,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_block_hash-query.err > logs/update_block_hash-query.out
-
-echo
-echo "the new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_block_hash.sh
+++ b/scripts/update_block_hash.sh
@@ -66,4 +66,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_collateral.sh
+++ b/scripts/update_collateral.sh
@@ -68,4 +68,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_collateral.sh
+++ b/scripts/update_collateral.sh
@@ -60,7 +60,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -68,14 +67,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_datum.sh
+++ b/scripts/update_datum.sh
@@ -56,7 +56,7 @@ function transform_csv() {
     return 0
 }
 
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_${SCHEMA}_1"
 CSVNAME="update_${SCHEMA}"
 
 Q="SELECT epoch_no, slot_no, txidx,

--- a/scripts/update_datum.sh
+++ b/scripts/update_datum.sh
@@ -92,4 +92,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_datum.sh
+++ b/scripts/update_datum.sh
@@ -92,4 +92,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q""
+echo "$Q"

--- a/scripts/update_datum.sh
+++ b/scripts/update_datum.sh
@@ -56,7 +56,7 @@ function transform_csv() {
     return 0
 }
 
-TMPTBL="update_${SCHEMA}"
+TMPTBL="tmp_${TNAME}_1"
 CSVNAME="update_${SCHEMA}"
 
 Q="SELECT epoch_no, slot_no, txidx,
@@ -84,7 +84,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "${PROJECTID}:${SRCDATASET}"
 
 
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -92,14 +91,5 @@ Q="
    SELECT * FROM ${PROJECTID}.${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id="${PROJECTID}:${TARGETDATASET}" --nouse_legacy_sql "${Q}" 2> logs/${CSVNAME}-query.err > logs/${CSVNAME}-query.out
-
-echo
-echo "table's ${SCHEMA} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q""

--- a/scripts/update_delegation.sh
+++ b/scripts/update_delegation.sh
@@ -82,7 +82,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    -- none to delete as we do not store the slot number in the table
    -- 2 insert new slots
@@ -90,14 +89,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_delegation.sh
+++ b/scripts/update_delegation.sh
@@ -90,4 +90,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_epoch_ada_pots.sh
+++ b/scripts/update_epoch_ada_pots.sh
@@ -34,7 +34,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into temporary table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
   SELECT epoch_no, slot_no,
          treasury, reserves, rewards, utxo,

--- a/scripts/update_epoch_delegation.sh
+++ b/scripts/update_epoch_delegation.sh
@@ -34,7 +34,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
   SELECT epoch_no, stake_addr_hash, delegations
   FROM analytics.vw_bq_delegation

--- a/scripts/update_epoch_epoch_param.sh
+++ b/scripts/update_epoch_epoch_param.sh
@@ -34,7 +34,7 @@ SCHEMA="epoch_param"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into table: tmp_epoch_param_1
-TMPTBL="tmp_epoch_param_1"
+TMPTBL="tmp_epoch_${SCHEMA}_1"
 Q="
     SELECT epoch_no, params
   FROM analytics.vw_bq_epoch_param

--- a/scripts/update_epoch_epoch_stake.sh
+++ b/scripts/update_epoch_epoch_stake.sh
@@ -34,7 +34,7 @@ SCHEMA="epoch_stake"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into table: tmp_epoch_stake_1
-TMPTBL="tmp_epoch_stake_1"
+TMPTBL="tmp_epoch_${SCHEMA}_1"
 Q="
   SELECT epoch_no,
          stake_addr_hash,

--- a/scripts/update_epoch_ma_minting.sh
+++ b/scripts/update_epoch_ma_minting.sh
@@ -35,7 +35,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
   SELECT fingerprint, policyid, name_bytes, epoch_no, minting
   FROM analytics.vw_bq_ma_minting

--- a/scripts/update_epoch_param_proposal.sh
+++ b/scripts/update_epoch_param_proposal.sh
@@ -34,7 +34,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
     SELECT epoch_no, params
     FROM analytics.vw_bq_param_proposal

--- a/scripts/update_epoch_pool_offline_data.sh
+++ b/scripts/update_epoch_pool_offline_data.sh
@@ -35,7 +35,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
   SELECT 
          pool_hash,

--- a/scripts/update_epoch_pool_update.sh
+++ b/scripts/update_epoch_pool_update.sh
@@ -35,7 +35,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
  SELECT active_epoch_no,
         pool_hash,

--- a/scripts/update_epoch_rel_addr_txout.sh
+++ b/scripts/update_epoch_rel_addr_txout.sh
@@ -35,7 +35,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
  SELECT *
   FROM analytics.vw_bq_rel_addr_txout(${EPOCH_NO})"

--- a/scripts/update_epoch_rel_stake_txout.sh
+++ b/scripts/update_epoch_rel_stake_txout.sh
@@ -35,7 +35,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
  SELECT *
   FROM analytics.vw_bq_rel_stake_txout(${EPOCH_NO})"

--- a/scripts/update_epoch_reward.sh
+++ b/scripts/update_epoch_reward.sh
@@ -34,7 +34,7 @@ SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert epoch into tmp table
-TMPTBL="tmp_${TNAME}_1"
+TMPTBL="tmp_epoch_${TNAME}_1"
 Q="
   SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
   FROM analytics.vw_bq_reward

--- a/scripts/update_ma_minting.sh
+++ b/scripts/update_ma_minting.sh
@@ -83,4 +83,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_ma_minting.sh
+++ b/scripts/update_ma_minting.sh
@@ -75,7 +75,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    -- none to delete as we do not store the slot number in the table
    -- 2 insert new slots
@@ -83,14 +82,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_pool_offline_data.sh
+++ b/scripts/update_pool_offline_data.sh
@@ -96,4 +96,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_pool_offline_data.sh
+++ b/scripts/update_pool_offline_data.sh
@@ -56,7 +56,7 @@ Q="
          pmr.url AS metadata_url,
          encode(pmr.hash, 'base64') AS metadata_hash,
          encode(tx.hash,'hex') AS metadata_registered_tx_hash
-  FROM public.pool_offline_data AS pod
+  FROM public.off_chain_pool_data AS pod
   LEFT JOIN public.pool_metadata_ref pmr ON pod.pmr_id = pmr.id
   JOIN public.pool_hash ph ON pod.pool_id = ph.id
   JOIN tx ON pmr.registered_tx_id = tx.id

--- a/scripts/update_pool_offline_data.sh
+++ b/scripts/update_pool_offline_data.sh
@@ -69,7 +69,7 @@ TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 #DRYRUN="--dry_run"
 DRYRUN=
 
-if [ -z "${NREAD}" -o $NREAD -lt 0 ]
+if [ -z "${NREAD}" ] || [ "$NREAD" -lt 0 ]
 then
   echo "Q: returned ${NREAD}.";
   exit 1;

--- a/scripts/update_pool_offline_data.sh
+++ b/scripts/update_pool_offline_data.sh
@@ -88,7 +88,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 # run the transaction
 SRCDATASET="${BQ_PROJECT}.db_sync"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    -- none to delete as we do not store the slot number in the table
    -- 2  insert new slots
@@ -96,11 +95,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_pool_owner.sh
+++ b/scripts/update_pool_owner.sh
@@ -79,7 +79,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 # run the transaction
 SRCDATASET="${BQ_PROJECT}.db_sync"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -87,11 +86,6 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
+echo "$Q"
 
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."

--- a/scripts/update_pool_owner.sh
+++ b/scripts/update_pool_owner.sh
@@ -87,5 +87,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
-
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_pool_retire.sh
+++ b/scripts/update_pool_retire.sh
@@ -89,4 +89,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_pool_retire.sh
+++ b/scripts/update_pool_retire.sh
@@ -81,7 +81,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 # run the transaction
 SRCDATASET="${BQ_PROJECT}.db_sync"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -89,11 +88,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_pool_update.sh
+++ b/scripts/update_pool_update.sh
@@ -103,4 +103,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_pool_update.sh
+++ b/scripts/update_pool_update.sh
@@ -95,7 +95,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 # run the transaction
 SRCDATASET="${BQ_PROJECT}.db_sync"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    -- none to delete as we do not store the slot number in the table
    -- 2 insert new slots
@@ -103,11 +102,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_redeemer.sh
+++ b/scripts/update_redeemer.sh
@@ -58,7 +58,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -66,14 +65,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_redeemer.sh
+++ b/scripts/update_redeemer.sh
@@ -66,4 +66,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_rel_addr_txout.sh
+++ b/scripts/update_rel_addr_txout.sh
@@ -116,4 +116,4 @@ Q="
    -- 2 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_rel_addr_txout.sh
+++ b/scripts/update_rel_addr_txout.sh
@@ -46,7 +46,7 @@ SRCDATASET="db_sync"
 TARGETDATASET="cardano_mainnet"
 TARGETTBL="${PROJECTID}.${TARGETDATASET}.${SCHEMA}"
 
-TMPTBL="update_${SCHEMA}"
+TMPTBL="tmp_${SCHEMA}_1"
 CSVNAME="update_${SCHEMA}"
 
 ## 1 insert slots (clean until max) into temporary table
@@ -110,20 +110,10 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "${PROJECTID}:${SRCDATASET}"
 
 # run the transaction
 Q="
-   BEGIN TRANSACTION;
    -- 1 insert new slots
    INSERT INTO ${TARGETTBL}
    SELECT * FROM ${PROJECTID}.${SRCDATASET}.${TMPTBL};
    -- 2 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id="${PROJECTID}:${TARGETDATASET}" --nouse_legacy_sql "${Q}" 2> logs/${CSVNAME}-query.err > logs/${CSVNAME}-query.out
-
-echo
-echo "table's ${SCHEMA} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_rel_stake_hash.sh
+++ b/scripts/update_rel_stake_hash.sh
@@ -55,7 +55,7 @@ function transform_csv() {
     return 0
 }
 
-TMPTBL="update_${SCHEMA}"
+TMPTBL="tmp_${SCHEMA}_1"
 CSVNAME="update_${SCHEMA}"
 
 Q="SELECT epoch_no, slot_no, stake_address, stake_addr_hash
@@ -81,7 +81,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "${PROJECTID}:${SRCDATASET}"
 
 
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -89,14 +88,5 @@ Q="
    SELECT * FROM ${PROJECTID}.${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id="${PROJECTID}:${TARGETDATASET}" --nouse_legacy_sql "${Q}" 2> logs/${CSVNAME}-query.err > logs/${CSVNAME}-query.out
-
-echo
-echo "table's ${SCHEMA} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_rel_stake_hash.sh
+++ b/scripts/update_rel_stake_hash.sh
@@ -89,4 +89,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_rel_stake_txout.sh
+++ b/scripts/update_rel_stake_txout.sh
@@ -91,7 +91,7 @@ Q="
    -- 2 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"
 
 
 function transform_csv() {

--- a/scripts/update_rel_stake_txout.sh
+++ b/scripts/update_rel_stake_txout.sh
@@ -42,7 +42,7 @@ SCHEMA="rel_stake_txout"
 DATASETID="${BQ_PROJECT}:db_sync"
 
 ## 1 insert slots (clean until max) into table: tmp_rel_stake_txout_1
-TMPTBL="tmp_rel_stake_txout_1"
+TMPTBL="tmp_${SCHEMA}_1"
 Q="with dat AS
          (SELECT block.epoch_no,
                  sa.view        AS address,
@@ -85,23 +85,14 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.rel_stake_txout"
 Q="
-   BEGIN TRANSACTION;
    -- 1 insert new slots
    INSERT INTO ${TARGETTBL}
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 2 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
+echo "$Q"
 
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_rel_stake_txout-query.err > logs/update_rel_stake_txout-query.out
-
-echo
-echo "the new block height: ${MAX_SLOT_NO}"
-echo "all done."
 
 function transform_csv() {
 	local FNAME=$1

--- a/scripts/update_script.sh
+++ b/scripts/update_script.sh
@@ -91,7 +91,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 # run the transaction
 SRCDATASET="${BQ_PROJECT}.db_sync"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -99,11 +98,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_script.sh
+++ b/scripts/update_script.sh
@@ -99,4 +99,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_stake_deregistration.sh
+++ b/scripts/update_stake_deregistration.sh
@@ -74,4 +74,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_stake_deregistration.sh
+++ b/scripts/update_stake_deregistration.sh
@@ -66,7 +66,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -74,14 +73,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_stake_registration.sh
+++ b/scripts/update_stake_registration.sh
@@ -74,4 +74,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_stake_registration.sh
+++ b/scripts/update_stake_registration.sh
@@ -66,7 +66,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -74,14 +73,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_tx.sh
+++ b/scripts/update_tx.sh
@@ -42,7 +42,7 @@ DATASETID="${BQ_PROJECT}:db_sync"
 ## 1 delete slots 
 
 ## 2 insert slots (clean until max) into table: tmp_tx_1
-TMPTBL="tmp_tx_1"
+TMPTBL="tmp_${SCHEMA}_1"
 Q="
   SELECT epoch_no, tx_hash,
          block_time, slot_no, txidx,
@@ -62,7 +62,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.tx"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -70,14 +69,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_tx-query.err > logs/update_tx-query.out
-
-echo
-echo "the new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_tx.sh
+++ b/scripts/update_tx.sh
@@ -70,4 +70,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_tx_consumed_output.sh
+++ b/scripts/update_tx_consumed_output.sh
@@ -87,4 +87,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_tx_consumed_output.sh
+++ b/scripts/update_tx_consumed_output.sh
@@ -79,7 +79,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 # run the transaction
 SRCDATASET="${BQ_PROJECT}.db_sync"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE consumed_in_slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -87,11 +86,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_tx_hash.sh
+++ b/scripts/update_tx_hash.sh
@@ -65,4 +65,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_tx_hash.sh
+++ b/scripts/update_tx_hash.sh
@@ -43,7 +43,7 @@ DATASETID="${BQ_PROJECT}:db_sync"
 ## 1 delete slots 
 
 ## 2 insert slots (clean until max) into table: tmp_tx_hash_1
-TMPTBL="tmp_tx_hash_1"
+TMPTBL="tmp_${SCHEMA}_1"
 Q="
   SELECT epoch_no, slot_no, txidx, tx_hash
   FROM analytics.vw_bq_tx_hash
@@ -57,7 +57,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.tx_hash"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -65,14 +64,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_tx_hash-query.err > logs/update_tx_hash-query.out
-
-echo
-echo "the new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_tx_in_out.sh
+++ b/scripts/update_tx_in_out.sh
@@ -67,4 +67,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_tx_in_out.sh
+++ b/scripts/update_tx_in_out.sh
@@ -46,7 +46,7 @@ TARGETTBL="${PROJECTID}.${TARGETDATASET}.${SCHEMA}"
 ## 1 delete slots (no preparation needed)
 
 ## 2 insert slots (clean until max) into table: t3
-TMPTBL="update_${SCHEMA}"
+TMPTBL="tmp_${SCHEMA}_1"
 CSVNAME="update_${SCHEMA}"
 
 Q="SELECT epoch_no, slot_no, txidx, inputs, outputs
@@ -59,7 +59,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "${PROJECTID}:${SRCDATASET}"
 
 # run the transaction
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -67,14 +66,5 @@ Q="
    SELECT * FROM ${PROJECTID}.${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id="${PROJECTID}:${TARGETDATASET}" --nouse_legacy_sql "${Q}" 2> logs/${CSVNAME}-query.err > logs/${CSVNAME}-query.out
-
-echo
-echo "the new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_tx_metadata.sh
+++ b/scripts/update_tx_metadata.sh
@@ -69,7 +69,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -77,14 +76,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_tx_metadata.sh
+++ b/scripts/update_tx_metadata.sh
@@ -77,4 +77,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"

--- a/scripts/update_withdrawal.sh
+++ b/scripts/update_withdrawal.sh
@@ -73,7 +73,6 @@ bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
 SRCDATASET="${BQ_PROJECT}.db_sync"
 TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
 Q="
-   BEGIN TRANSACTION;
    -- 1 delete slots
    DELETE FROM ${TARGETTBL} WHERE slot_no >= ${CLEAN_SLOT_NO};
    -- 2 insert new slots
@@ -81,14 +80,5 @@ Q="
    SELECT * FROM ${SRCDATASET}.${TMPTBL};
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
-   COMMIT TRANSACTION;
 "
-
-#DRYRUN="--dry_run"
-DRYRUN=
-
-${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
-
-echo
-echo "table's ${TNAME} new block height: ${MAX_SLOT_NO}"
-echo "all done."
+echo "$Q"

--- a/scripts/update_withdrawal.sh
+++ b/scripts/update_withdrawal.sh
@@ -81,4 +81,4 @@ Q="
    -- 3 update the last index table
    UPDATE db_sync.last_index set last_slot_no=${MAX_SLOT_NO} WHERE tablename='${TARGETTBL}';
 "
-echo "$Q"
+echo "$Q" > "/tmp/${SCHEMA}-query.sql"


### PR DESCRIPTION
This PR attempts to make the updates more atomic.
Every table update script instead of performing the update, returns the SQL query that needs to be done.
All the SQL queries are then concatenated in one big string that gets executed as a single transaction.

The benefit of this is that we have more atomic updates. 
The drawback is that in case a table falls back, it won't catch up as it used to do 

**Update**
This has been tested successfully:
Created a transaction text using the script and then run it against the `test1` dataset in BigQuery.
The output of transaction is:
```
Duration             1 min 27 sec
Bytes processed      11.8 MB
Bytes billed         570 MB
Slot milliseconds    74818
```

Notes about the changes:
- Each update script now outputs the text of the BigQuery sql that should be executed, without executing it
- The script is saved in a file under `/tmp`
- We used the convention of `tmp_<tablename>` and `tmp_epoch_<tablename>` for all temporary tables created in db-sync dataset
- Added a fix in pool_offline_data