### PR TITLE
new table copies clustered by pool_hash, stake_addr_hash

### DIFF
--- a/schema/tables/epoch_stake_addr.json
+++ b/schema/tables/epoch_stake_addr.json
@@ -1,0 +1,26 @@
+[
+  {
+    "description": "The epoch number.",
+    "name": "epoch_no",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The hash identifier of the stake address.",
+    "name": "stake_addr_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The hash of the pool that this entry is delegated to.",
+    "name": "pool_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The amount (in Lovelace) being staked.",
+    "name": "amount",
+    "type": "NUMERIC",
+    "mode": "REQUIRED"
+  }
+]

--- a/schema/tables/epoch_stake_pool.json
+++ b/schema/tables/epoch_stake_pool.json
@@ -1,0 +1,26 @@
+[
+  {
+    "description": "The epoch number.",
+    "name": "epoch_no",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The hash identifier of the stake address.",
+    "name": "stake_addr_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The hash of the pool that this entry is delegated to.",
+    "name": "pool_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The amount (in Lovelace) being staked.",
+    "name": "amount",
+    "type": "NUMERIC",
+    "mode": "REQUIRED"
+  }
+]

--- a/schema/tables/reward_addr.json
+++ b/schema/tables/reward_addr.json
@@ -1,0 +1,38 @@
+[
+  {
+    "description": "The spendable epoch number",
+    "name": "epoch_no",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The StakeAddress table index for the stake address that earned the reward.",
+    "name": "stake_addr_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The source of the rewards; pool member, pool leader, treasury or reserves payment and pool deposits refunds",
+    "name": "type",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The reward amount (in Lovelace).",
+    "name": "amount",
+    "type": "NUMERIC",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The epoch in which the reward was earned. For pool and leader rewards spendable in epoch N, this will be N - 2, for treasury and reserves N - 1 and for refund N.",
+    "name": "earned_epoch",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The PoolHash table index for the pool the stake address was delegated to when the reward is earned or for the pool that there is a deposit refund. Will be NULL for payments from the treasury or the reserves.",
+    "name": "pool_hash",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  }
+]

--- a/schema/tables/reward_pool.json
+++ b/schema/tables/reward_pool.json
@@ -1,0 +1,38 @@
+[
+  {
+    "description": "The spendable epoch number",
+    "name": "epoch_no",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The StakeAddress table index for the stake address that earned the reward.",
+    "name": "stake_addr_hash",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The source of the rewards; pool member, pool leader, treasury or reserves payment and pool deposits refunds",
+    "name": "type",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The reward amount (in Lovelace).",
+    "name": "amount",
+    "type": "NUMERIC",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The epoch in which the reward was earned. For pool and leader rewards spendable in epoch N, this will be N - 2, for treasury and reserves N - 1 and for refund N.",
+    "name": "earned_epoch",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "description": "The PoolHash table index for the pool the stake address was delegated to when the reward is earned or for the pool that there is a deposit refund. Will be NULL for payments from the treasury or the reserves.",
+    "name": "pool_hash",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  }
+]

--- a/scripts/deep_compare/epoch_tables.py
+++ b/scripts/deep_compare/epoch_tables.py
@@ -7,6 +7,8 @@ def query_epoch_tables(epoch_no):
             #query_param_proposal(epoch_no),
             query_ada_pots(epoch_no),
             query_epoch_stake(epoch_no)
+            query_epoch_stake_addr(epoch_no)
+            query_epoch_stake_pool(epoch_no)
     ]
 
 
@@ -203,6 +205,58 @@ def query_epoch_stake(epoch_no):
                 ||',' || (amount)
                 ||')' AS str
                 FROM cardano_mainnet.epoch_stake
+                WHERE epoch_no = {epoch_no}
+                ORDER BY epoch_no, stake_addr_hash, pool_hash ASC))
+                AS innerq;""",
+            f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
+                (SELECT STRING_AGG(encode(SHA256(subq.str::bytea),'base64'), ',')::bytea AS hash_b64 FROM
+                (SELECT
+                '('|| (epoch_no)
+                ||',' || (stake_addr_hash)
+                ||',' || (pool_hash)
+                ||',' || (amount)
+                ||')' AS str
+                FROM analytics.vw_bq_epoch_stake WHERE epoch_no = {epoch_no}) AS subq
+                ) AS innerq;""",
+            lambda x: x, lambda x: x)
+
+
+def query_epoch_stake_pool(epoch_no):
+    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+                (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
+                (SELECT
+                '('|| (epoch_no)
+                ||',' || (stake_addr_hash)
+                ||',' || (pool_hash)
+                ||',' || (amount)
+                ||')' AS str
+                FROM cardano_mainnet.epoch_stake_pool
+                WHERE epoch_no = {epoch_no}
+                ORDER BY epoch_no, stake_addr_hash, pool_hash ASC))
+                AS innerq;""",
+            f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
+                (SELECT STRING_AGG(encode(SHA256(subq.str::bytea),'base64'), ',')::bytea AS hash_b64 FROM
+                (SELECT
+                '('|| (epoch_no)
+                ||',' || (stake_addr_hash)
+                ||',' || (pool_hash)
+                ||',' || (amount)
+                ||')' AS str
+                FROM analytics.vw_bq_epoch_stake WHERE epoch_no = {epoch_no}) AS subq
+                ) AS innerq;""",
+            lambda x: x, lambda x: x)
+
+
+def query_epoch_stake_addr(epoch_no):
+    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+                (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
+                (SELECT
+                '('|| (epoch_no)
+                ||',' || (stake_addr_hash)
+                ||',' || (pool_hash)
+                ||',' || (amount)
+                ||')' AS str
+                FROM cardano_mainnet.epoch_stake_addr
                 WHERE epoch_no = {epoch_no}
                 ORDER BY epoch_no, stake_addr_hash, pool_hash ASC))
                 AS innerq;""",

--- a/scripts/deep_compare/epoch_tables.py
+++ b/scripts/deep_compare/epoch_tables.py
@@ -1,172 +1,171 @@
-import json
-import pandas as pd
 
 def query_epoch_tables(epoch_no):
     return [
-            #query_epoch_param(epoch_no),
-            #query_param_proposal(epoch_no),
-            query_ada_pots(epoch_no),
-            query_epoch_stake(epoch_no)
-            query_epoch_stake_addr(epoch_no)
-            query_epoch_stake_pool(epoch_no)
+        # query_epoch_param(epoch_no),
+        # query_param_proposal(epoch_no),
+        query_ada_pots(epoch_no),
+        query_epoch_stake(epoch_no),
+        query_epoch_stake_addr(epoch_no),
+        query_epoch_stake_pool(epoch_no),
     ]
 
 
-#def query_epoch_param(epoch_no):
+# def query_epoch_param(epoch_no):
 #    return (f"""SELECT TO_BASE64(SHA256(innerq.str)) AS hash_b64 FROM
 #                 (SELECT
 #                    '('|| (epoch_no)
 #                       ||',' || (min_fee_a)
 #                       ||',' || (min_fee_b)
-#                       ||',' || (max_block_size) 
+#                       ||',' || (max_block_size)
 #                       ||',' || (max_tx_size)
-#                       ||',' || (max_bh_size)    
-#                       ||',' || (key_deposit) 
+#                       ||',' || (max_bh_size)
+#                       ||',' || (key_deposit)
 #                       ||',' || (pool_deposit)
-#                       ||',' || (max_epoch)    
-#                       ||',' || (optimal_pool_count) 
-#                       ||',' || (influence)                 
-#                       ||',' || (monetary_expand_rate) 
+#                       ||',' || (max_epoch)
+#                       ||',' || (optimal_pool_count)
+#                       ||',' || (influence)
+#                       ||',' || (monetary_expand_rate)
 #                       ||',' || (treasury_growth_rate)
-#                       ||',' || (decentralisation)    
-#                       ||',' || (COALESCE(extra_entropy, 'null')) 
-#                       ||',' || (protocol_major)                 
-#                       ||',' || (protocol_minor) 
-#                       ||',' || (min_utxo_value)   
-#                       ||',' || (min_pool_cost)    
+#                       ||',' || (decentralisation)
+#                       ||',' || (COALESCE(extra_entropy, 'null'))
+#                       ||',' || (protocol_major)
+#                       ||',' || (protocol_minor)
+#                       ||',' || (min_utxo_value)
+#                       ||',' || (min_pool_cost)
 #                       ||',' || (COALESCE(nonce, 'null'))
-#                       ||',' || (COALESCE(CAST(coins_per_utxo_size AS STRING), 'null'))          
-#                       ||',' || (COALESCE(CAST(price_mem AS STRING) , 'null'))      
-#                       ||',' || (COALESCE(CAST(price_step AS STRING) , 'null'))       
-#                       ||',' || (COALESCE(CAST(max_tx_ex_mem AS STRING) , 'null'))       
-#                       ||',' || (COALESCE(CAST(max_tx_ex_steps AS STRING) , 'null'))       
-#                       ||',' || (COALESCE(CAST(max_block_ex_mem AS STRING) , 'null'))       
-#                       ||',' || (COALESCE(CAST(max_block_ex_steps AS STRING) , 'null'))       
-#                       ||',' || (COALESCE(CAST(max_val_size AS STRING) , 'null'))       
-#                       ||',' || (COALESCE(CAST(collateral_percent AS STRING) , 'null'))       
-#                       ||',' || (COALESCE(CAST(max_collateral_inputs AS STRING) , 'null'))       
+#                       ||',' || (COALESCE(CAST(coins_per_utxo_size AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(price_mem AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(price_step AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(max_tx_ex_mem AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(max_tx_ex_steps AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(max_block_ex_mem AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(max_block_ex_steps AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(max_val_size AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(collateral_percent AS STRING) , 'null'))
+#                       ||',' || (COALESCE(CAST(max_collateral_inputs AS STRING) , 'null'))
 #                       ||')' AS str
 #                  FROM cardano_mainnet.epoch_param
 #                  WHERE epoch_no = {epoch_no}
 #                ) AS innerq;""",
 #            f"""SELECT encode(SHA256(subq.str::bytea),'base64') AS hash_b64 FROM
-#                    (SELECT 
+#                    (SELECT
 #                    '('|| (epoch_no)
 #                       ||',' || (min_fee_a)
 #                       ||',' || (min_fee_b)
-#                       ||',' || (max_block_size) 
+#                       ||',' || (max_block_size)
 #                       ||',' || (max_tx_size)
-#                       ||',' || (max_bh_size)    
-#                       ||',' || (key_deposit) 
+#                       ||',' || (max_bh_size)
+#                       ||',' || (key_deposit)
 #                       ||',' || (pool_deposit)
-#                       ||',' || (max_epoch)    
-#                       ||',' || (optimal_pool_count) 
-#                       ||',' || (influence)                 
-#                       ||',' || (monetary_expand_rate) 
+#                       ||',' || (max_epoch)
+#                       ||',' || (optimal_pool_count)
+#                       ||',' || (influence)
+#                       ||',' || (monetary_expand_rate)
 #                       ||',' || (treasury_growth_rate)
-#                       ||',' || (decentralisation)    
-#                       ||',' || (COALESCE(extra_entropy, 'null'))  
-#                       ||',' || (protocol_major)                 
-#                       ||',' || (protocol_minor) 
-#                       ||',' || (min_utxo_value)   
-#                       ||',' || (min_pool_cost)    
+#                       ||',' || (decentralisation)
+#                       ||',' || (COALESCE(extra_entropy, 'null'))
+#                       ||',' || (protocol_major)
+#                       ||',' || (protocol_minor)
+#                       ||',' || (min_utxo_value)
+#                       ||',' || (min_pool_cost)
 #                       ||',' || (COALESCE(nonce, 'null'))
-#                       ||',' || (COALESCE(coins_per_utxo_size::text, 'null'))            
-#                       ||',' || (COALESCE(price_mem::text, 'null'))      
-#                       ||',' || (COALESCE(to_char(price_step, 'FM90.9999999'), 'null'))       
-#                       ||',' || (COALESCE(max_tx_ex_mem::text, 'null'))       
-#                       ||',' || (COALESCE(max_tx_ex_steps::text, 'null'))       
-#                       ||',' || (COALESCE(max_block_ex_mem::text, 'null'))       
-#                       ||',' || (COALESCE(max_block_ex_steps::text, 'null'))       
-#                       ||',' || (COALESCE(max_val_size::text, 'null'))       
-#                       ||',' || (COALESCE(collateral_percent::text, 'null'))       
-#                       ||',' || (COALESCE(max_collateral_inputs::text, 'null'))       
+#                       ||',' || (COALESCE(coins_per_utxo_size::text, 'null'))
+#                       ||',' || (COALESCE(price_mem::text, 'null'))
+#                       ||',' || (COALESCE(to_char(price_step, 'FM90.9999999'), 'null'))
+#                       ||',' || (COALESCE(max_tx_ex_mem::text, 'null'))
+#                       ||',' || (COALESCE(max_tx_ex_steps::text, 'null'))
+#                       ||',' || (COALESCE(max_block_ex_mem::text, 'null'))
+#                       ||',' || (COALESCE(max_block_ex_steps::text, 'null'))
+#                       ||',' || (COALESCE(max_val_size::text, 'null'))
+#                       ||',' || (COALESCE(collateral_percent::text, 'null'))
+#                       ||',' || (COALESCE(max_collateral_inputs::text, 'null'))
 #                       ||')' AS str
 #                      FROM analytics.vw_bq_epoch_param WHERE epoch_no = {epoch_no}) AS subq""",
 #            lambda x: x, lambda x: x)
 
 
-#def query_param_proposal(epoch_no):
+# def query_param_proposal(epoch_no):
 #    return (f"""SELECT TO_BASE64(SHA256(innerq.str)) AS hash_b64 FROM
 #                 (SELECT
 #                    '('|| (epoch_no)
 #                       ||',' || (key)
 #                       ||',' || (COALESCE(CAST(min_fee_a AS STRING), 'null'))
-#                       ||',' || (COALESCE(CAST(min_fee_b AS STRING), 'null')) 
+#                       ||',' || (COALESCE(CAST(min_fee_b AS STRING), 'null'))
 #                       ||',' || (COALESCE(CAST(max_block_size AS STRING), 'null'))
-#                       ||',' || (COALESCE(CAST(max_tx_size AS STRING), 'null'))    
-#                       ||',' || (COALESCE(CAST(max_bh_size AS STRING), 'null')) 
+#                       ||',' || (COALESCE(CAST(max_tx_size AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_bh_size AS STRING), 'null'))
 #                       ||',' || (COALESCE(CAST(key_deposit AS STRING), 'null'))
-#                       ||',' || (COALESCE(CAST(pool_deposit AS STRING), 'null'))    
-#                       ||',' || (COALESCE(CAST(max_epoch AS STRING), 'null')) 
-#                       ||',' || (COALESCE(CAST(optimal_pool_count AS STRING), 'null'))                 
-#                       ||',' || (COALESCE(CAST(influence AS STRING), 'null')) 
+#                       ||',' || (COALESCE(CAST(pool_deposit AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_epoch AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(optimal_pool_count AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(influence AS STRING), 'null'))
 #                       ||',' || (COALESCE(CAST(monetary_expand_rate AS STRING), 'null'))
-#                       ||',' || (COALESCE(CAST(treasury_growth_rate AS STRING), 'null'))    
-#                       ||',' || (COALESCE(CAST(decentralisation AS STRING), 'null')) 
-#                       ||',' || (COALESCE(CAST(entropy AS STRING), 'null'))                 
-#                       ||',' || (COALESCE(CAST(protocol_major AS STRING), 'null')) 
-#                       ||',' || (COALESCE(CAST(protocol_minor AS STRING), 'null'))   
-#                       ||',' || (COALESCE(CAST(min_utxo_value AS STRING), 'null'))    
-#                       ||',' || (COALESCE(CAST(min_pool_cost AS STRING), 'null')) 
-#                       ||',' || (COALESCE(CAST(coins_per_utxo_size AS STRING), 'null'))                 
-#                       ||',' || (COALESCE(CAST(price_mem AS STRING), 'null'))      
-#                       ||',' || (COALESCE(CAST(price_step AS STRING), 'null'))       
-#                       ||',' || (COALESCE(CAST(max_tx_ex_mem AS STRING), 'null'))       
-#                       ||',' || (COALESCE(CAST(max_tx_ex_steps AS STRING), 'null'))       
-#                       ||',' || (COALESCE(CAST(max_block_ex_mem AS STRING), 'null'))       
-#                       ||',' || (COALESCE(CAST(max_block_ex_steps AS STRING), 'null'))       
-#                       ||',' || (COALESCE(CAST(max_val_size AS STRING), 'null'))       
-#                       ||',' || (COALESCE(CAST(collateral_percent AS STRING), 'null'))       
-#                       ||',' || (COALESCE(CAST(max_collateral_inputs AS STRING), 'null'))     
-#                       ||',' || (registered_tx_slot_no)       
-#                       ||',' || (registered_tx_index)    
+#                       ||',' || (COALESCE(CAST(treasury_growth_rate AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(decentralisation AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(entropy AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(protocol_major AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(protocol_minor AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(min_utxo_value AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(min_pool_cost AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(coins_per_utxo_size AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(price_mem AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(price_step AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_tx_ex_mem AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_tx_ex_steps AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_block_ex_mem AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_block_ex_steps AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_val_size AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(collateral_percent AS STRING), 'null'))
+#                       ||',' || (COALESCE(CAST(max_collateral_inputs AS STRING), 'null'))
+#                       ||',' || (registered_tx_slot_no)
+#                       ||',' || (registered_tx_index)
 #                       ||')' AS str
 #                  FROM cardano_mainnet.param_proposal
 #                  WHERE epoch_no = {epoch_no}
 #                  ORDER BY epoch_no, registered_tx_slot_no, registered_tx_index, key ASC
 #                ) AS innerq;""",
 #            f"""SELECT encode(SHA256(subq.str::bytea),'base64') AS hash_b64 FROM
-#                    (SELECT 
+#                    (SELECT
 #                    '('|| (epoch_no)
 #                       ||',' || ("key")
 #                       ||',' || (COALESCE(min_fee_a::text, 'null'))
-#                       ||',' || (COALESCE(min_fee_b::text, 'null')) 
+#                       ||',' || (COALESCE(min_fee_b::text, 'null'))
 #                       ||',' || (COALESCE(max_block_size::text, 'null'))
-#                       ||',' || (COALESCE(max_tx_size::text, 'null'))    
-#                       ||',' || (COALESCE(max_bh_size::text, 'null')) 
+#                       ||',' || (COALESCE(max_tx_size::text, 'null'))
+#                       ||',' || (COALESCE(max_bh_size::text, 'null'))
 #                       ||',' || (COALESCE(key_deposit::text, 'null'))
-#                       ||',' || (COALESCE(pool_deposit::text, 'null'))    
-#                       ||',' || (COALESCE(max_epoch::text, 'null')) 
-#                       ||',' || (COALESCE(optimal_pool_count::text, 'null'))                 
-#                       ||',' || (COALESCE(influence::text, 'null')) 
+#                       ||',' || (COALESCE(pool_deposit::text, 'null'))
+#                       ||',' || (COALESCE(max_epoch::text, 'null'))
+#                       ||',' || (COALESCE(optimal_pool_count::text, 'null'))
+#                       ||',' || (COALESCE(influence::text, 'null'))
 #                       ||',' || (COALESCE(monetary_expand_rate::text, 'null'))
-#                       ||',' || (COALESCE(treasury_growth_rate::text, 'null'))    
-#                       ||',' || (COALESCE(decentralisation::text, 'null')) 
-#                       ||',' || (COALESCE(entropy, 'null'))                 
-#                       ||',' || (COALESCE(protocol_major::text, 'null')) 
-#                       ||',' || (COALESCE(protocol_minor::text, 'null'))   
-#                       ||',' || (COALESCE(min_utxo_value::text, 'null'))    
-#                       ||',' || (COALESCE(min_pool_cost::text, 'null')) 
-#                       ||',' || (COALESCE(coins_per_utxo_size::text, 'null'))                 
-#                       ||',' || (COALESCE(price_mem::text, 'null'))      
-#                       ||',' || (COALESCE(price_step::text, 'null'))       
-#                       ||',' || (COALESCE(max_tx_ex_mem::text, 'null'))       
-#                       ||',' || (COALESCE(max_tx_ex_steps::text, 'null'))       
-#                       ||',' || (COALESCE(max_block_ex_mem::text, 'null'))       
-#                       ||',' || (COALESCE(max_block_ex_steps::text, 'null'))       
-#                       ||',' || (COALESCE(max_val_size::text, 'null'))       
-#                       ||',' || (COALESCE(collateral_percent::text, 'null'))       
-#                       ||',' || (COALESCE(max_collateral_inputs::text, 'null'))  
-#                       ||',' || (registered_tx_slot_no)       
-#                       ||',' || (registered_tx_index)  
+#                       ||',' || (COALESCE(treasury_growth_rate::text, 'null'))
+#                       ||',' || (COALESCE(decentralisation::text, 'null'))
+#                       ||',' || (COALESCE(entropy, 'null'))
+#                       ||',' || (COALESCE(protocol_major::text, 'null'))
+#                       ||',' || (COALESCE(protocol_minor::text, 'null'))
+#                       ||',' || (COALESCE(min_utxo_value::text, 'null'))
+#                       ||',' || (COALESCE(min_pool_cost::text, 'null'))
+#                       ||',' || (COALESCE(coins_per_utxo_size::text, 'null'))
+#                       ||',' || (COALESCE(price_mem::text, 'null'))
+#                       ||',' || (COALESCE(price_step::text, 'null'))
+#                       ||',' || (COALESCE(max_tx_ex_mem::text, 'null'))
+#                       ||',' || (COALESCE(max_tx_ex_steps::text, 'null'))
+#                       ||',' || (COALESCE(max_block_ex_mem::text, 'null'))
+#                       ||',' || (COALESCE(max_block_ex_steps::text, 'null'))
+#                       ||',' || (COALESCE(max_val_size::text, 'null'))
+#                       ||',' || (COALESCE(collateral_percent::text, 'null'))
+#                       ||',' || (COALESCE(max_collateral_inputs::text, 'null'))
+#                       ||',' || (registered_tx_slot_no)
+#                       ||',' || (registered_tx_index)
 #                       ||')' AS str
 #                      FROM analytics.vw_bq_param_proposal WHERE epoch_no = {epoch_no}) AS subq""",
 #            lambda x: x, lambda x: x)
 
 
 def query_ada_pots(epoch_no):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.str)) AS hash_b64 FROM
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.str)) AS hash_b64 FROM
                  (SELECT
                     '('|| (epoch_no)
                        ||',' || (slot_no)
@@ -180,7 +179,7 @@ def query_ada_pots(epoch_no):
                   FROM cardano_mainnet.ada_pots
                   WHERE epoch_no = {epoch_no}
                 ) AS innerq;""",
-            f"""SELECT encode(SHA256(subq.str::bytea),'base64') AS hash_b64 FROM
+        f"""SELECT encode(SHA256(subq.str::bytea),'base64') AS hash_b64 FROM
                     (SELECT
                     '('|| (epoch_no)
                        ||',' || (slot_no)
@@ -192,11 +191,14 @@ def query_ada_pots(epoch_no):
                        ||',' || (fees)
                        ||')' AS str
                       FROM public.ada_pots WHERE epoch_no = {epoch_no}) AS subq""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )
 
 
 def query_epoch_stake(epoch_no):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
                 (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
                 (SELECT
                 '('|| (epoch_no)
@@ -208,7 +210,7 @@ def query_epoch_stake(epoch_no):
                 WHERE epoch_no = {epoch_no}
                 ORDER BY epoch_no, stake_addr_hash, pool_hash ASC))
                 AS innerq;""",
-            f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
+        f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(subq.str::bytea),'base64'), ',')::bytea AS hash_b64 FROM
                 (SELECT
                 '('|| (epoch_no)
@@ -218,11 +220,14 @@ def query_epoch_stake(epoch_no):
                 ||')' AS str
                 FROM analytics.vw_bq_epoch_stake WHERE epoch_no = {epoch_no}) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )
 
 
 def query_epoch_stake_pool(epoch_no):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
                 (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
                 (SELECT
                 '('|| (epoch_no)
@@ -234,7 +239,7 @@ def query_epoch_stake_pool(epoch_no):
                 WHERE epoch_no = {epoch_no}
                 ORDER BY epoch_no, stake_addr_hash, pool_hash ASC))
                 AS innerq;""",
-            f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
+        f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(subq.str::bytea),'base64'), ',')::bytea AS hash_b64 FROM
                 (SELECT
                 '('|| (epoch_no)
@@ -244,11 +249,14 @@ def query_epoch_stake_pool(epoch_no):
                 ||')' AS str
                 FROM analytics.vw_bq_epoch_stake WHERE epoch_no = {epoch_no}) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )
 
 
 def query_epoch_stake_addr(epoch_no):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
                 (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
                 (SELECT
                 '('|| (epoch_no)
@@ -260,7 +268,7 @@ def query_epoch_stake_addr(epoch_no):
                 WHERE epoch_no = {epoch_no}
                 ORDER BY epoch_no, stake_addr_hash, pool_hash ASC))
                 AS innerq;""",
-            f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
+        f"""SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(subq.str::bytea),'base64'), ',')::bytea AS hash_b64 FROM
                 (SELECT
                 '('|| (epoch_no)
@@ -270,4 +278,6 @@ def query_epoch_stake_addr(epoch_no):
                 ||')' AS str
                 FROM analytics.vw_bq_epoch_stake WHERE epoch_no = {epoch_no}) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )

--- a/scripts/deep_compare/staking_tables.py
+++ b/scripts/deep_compare/staking_tables.py
@@ -7,6 +7,7 @@ def query_staking_tables(epoch_no):
         query_stake_deregistration(epoch_no),
         query_reward(epoch_no),
         query_reward_pool(epoch_no),
+        query_reward_addr(epoch_no),
         query_withdrawal(epoch_no),
         query_delegation(epoch_no),
     ]
@@ -143,6 +144,46 @@ def query_reward_pool(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
               FROM
               (SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
                  FROM `{bq_project}.cardano_mainnet.reward_pool`
+                 WHERE epoch_no = {epoch_no}
+                 ORDER BY epoch_no, stake_addr_hash, type, pool_hash ASC))
+            ) AS innerq;""",
+        f"""WITH dat AS
+                (SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
+                FROM analytics.vw_bq_reward
+                WHERE epoch_no = {epoch_no})
+
+                SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
+                (SELECT STRING_AGG(encode(SHA256(regexp_replace(regexp_replace(subq.str, '[\n]', '', 'g'), '[\s]', '', 'g')::bytea),'base64'), ',')::bytea AS hash_b64 FROM
+                 (SELECT
+                    '('|| (epoch_no)
+                    ||',' || (stake_addr_hash)
+                    ||',' || (type)
+                    ||',' || (amount)
+                    ||',' || (earned_epoch)
+                    ||',' || (pool_hash)
+                    ||')' AS str
+                  FROM dat) AS subq
+                ) AS innerq;""",
+        lambda x: x,
+        lambda x: x,
+    )
+
+
+def query_reward_addr(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+            (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
+             (SELECT
+                '('|| (epoch_no)
+                ||',' || (stake_addr_hash)
+                ||',' || (type)
+                ||',' || (amount)
+                ||',' || (earned_epoch)
+                ||',' || (pool_hash)
+                ||')' AS str
+              FROM
+              (SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
+                 FROM `{bq_project}.cardano_mainnet.reward_addr`
                  WHERE epoch_no = {epoch_no}
                  ORDER BY epoch_no, stake_addr_hash, type, pool_hash ASC))
             ) AS innerq;""",

--- a/scripts/deep_compare/staking_tables.py
+++ b/scripts/deep_compare/staking_tables.py
@@ -1,17 +1,20 @@
 import os
 
+
 def query_staking_tables(epoch_no):
     return [
-            query_stake_registration(epoch_no),
-            query_stake_deregistration(epoch_no),
-            query_reward(epoch_no),
-            query_withdrawal(epoch_no),
-            query_delegation(epoch_no)
+        query_stake_registration(epoch_no),
+        query_stake_deregistration(epoch_no),
+        query_reward(epoch_no),
+        query_reward_pool(epoch_no),
+        query_withdrawal(epoch_no),
+        query_delegation(epoch_no),
     ]
 
 
-def query_stake_registration(epoch_no, bq_project = os.environ['BQ_PROJECT']):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+def query_stake_registration(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
             (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
              (SELECT
                 '('|| (epoch_no)
@@ -22,18 +25,18 @@ def query_stake_registration(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                 ||')' AS str
               FROM
               (SELECT epoch_no, slot_no, txidx, stake_addr_hash, cert_index
-                 FROM `{bq_project}.cardano_mainnet.stake_registration` 
+                 FROM `{bq_project}.cardano_mainnet.stake_registration`
                  WHERE epoch_no = {epoch_no}
                  ORDER BY epoch_no, slot_no, txidx, stake_addr_hash, cert_index ASC))
             ) AS innerq;""",
-            f"""WITH dat AS
+        f"""WITH dat AS
                 (SELECT epoch_no, slot_no, txidx, stake_addr_hash, cert_index
                 FROM analytics.vw_bq_stake_registration
                 WHERE epoch_no = {epoch_no})
-                
+
                 SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(subq.str::bytea),'base64'), ',')::bytea AS hash_b64 FROM
-                 (SELECT 
+                 (SELECT
                     '('|| (epoch_no)
                     ||',' || (slot_no)
                     ||',' || (txidx)
@@ -42,11 +45,14 @@ def query_stake_registration(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                     ||')' AS str
                   FROM dat) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )
 
 
-def query_stake_deregistration(epoch_no, bq_project = os.environ['BQ_PROJECT']):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+def query_stake_deregistration(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
             (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
              (SELECT
                 '('|| (epoch_no)
@@ -57,18 +63,18 @@ def query_stake_deregistration(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                 ||')' AS str
               FROM
               (SELECT epoch_no, slot_no, txidx, stake_addr_hash, cert_index
-                 FROM `{bq_project}.cardano_mainnet.stake_deregistration` 
+                 FROM `{bq_project}.cardano_mainnet.stake_deregistration`
                  WHERE epoch_no = {epoch_no}
                  ORDER BY epoch_no, slot_no, txidx, stake_addr_hash, cert_index ASC))
             ) AS innerq;""",
-            f"""WITH dat AS
+        f"""WITH dat AS
                 (SELECT epoch_no, slot_no, txidx, stake_addr_hash, cert_index
                 FROM analytics.vw_bq_stake_deregistration
                 WHERE epoch_no = {epoch_no})
-                
+
                 SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(subq.str::bytea),'base64'), ',')::bytea AS hash_b64 FROM
-                 (SELECT 
+                 (SELECT
                     '('|| (epoch_no)
                     ||',' || (slot_no)
                     ||',' || (txidx)
@@ -77,11 +83,14 @@ def query_stake_deregistration(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                     ||')' AS str
                   FROM dat) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )
 
 
-def query_reward(epoch_no, bq_project = os.environ['BQ_PROJECT']):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+def query_reward(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
             (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
              (SELECT
                 '('|| (epoch_no)
@@ -93,18 +102,18 @@ def query_reward(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                 ||')' AS str
               FROM
               (SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
-                 FROM `{bq_project}.cardano_mainnet.reward` 
+                 FROM `{bq_project}.cardano_mainnet.reward`
                  WHERE epoch_no = {epoch_no}
                  ORDER BY epoch_no, stake_addr_hash, type, pool_hash ASC))
             ) AS innerq;""",
-            f"""WITH dat AS
+        f"""WITH dat AS
                 (SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
                 FROM analytics.vw_bq_reward
                 WHERE epoch_no = {epoch_no})
-                
+
                 SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(regexp_replace(regexp_replace(subq.str, '[\n]', '', 'g'), '[\s]', '', 'g')::bytea),'base64'), ',')::bytea AS hash_b64 FROM
-                 (SELECT 
+                 (SELECT
                     '('|| (epoch_no)
                     ||',' || (stake_addr_hash)
                     ||',' || (type)
@@ -114,10 +123,54 @@ def query_reward(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                     ||')' AS str
                   FROM dat) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )
 
-def query_withdrawal(epoch_no, bq_project = os.environ['BQ_PROJECT']):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+
+def query_reward_pool(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+            (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
+             (SELECT
+                '('|| (epoch_no)
+                ||',' || (stake_addr_hash)
+                ||',' || (type)
+                ||',' || (amount)
+                ||',' || (earned_epoch)
+                ||',' || (pool_hash)
+                ||')' AS str
+              FROM
+              (SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
+                 FROM `{bq_project}.cardano_mainnet.reward_pool`
+                 WHERE epoch_no = {epoch_no}
+                 ORDER BY epoch_no, stake_addr_hash, type, pool_hash ASC))
+            ) AS innerq;""",
+        f"""WITH dat AS
+                (SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
+                FROM analytics.vw_bq_reward
+                WHERE epoch_no = {epoch_no})
+
+                SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
+                (SELECT STRING_AGG(encode(SHA256(regexp_replace(regexp_replace(subq.str, '[\n]', '', 'g'), '[\s]', '', 'g')::bytea),'base64'), ',')::bytea AS hash_b64 FROM
+                 (SELECT
+                    '('|| (epoch_no)
+                    ||',' || (stake_addr_hash)
+                    ||',' || (type)
+                    ||',' || (amount)
+                    ||',' || (earned_epoch)
+                    ||',' || (pool_hash)
+                    ||')' AS str
+                  FROM dat) AS subq
+                ) AS innerq;""",
+        lambda x: x,
+        lambda x: x,
+    )
+
+
+def query_withdrawal(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
             (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
              (SELECT
                 '('|| (epoch_no)
@@ -128,18 +181,18 @@ def query_withdrawal(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                 ||')' AS str
               FROM
               (SELECT epoch_no, stake_addr_hash, amount, slot_no, txidx
-                 FROM `{bq_project}.cardano_mainnet.withdrawal` 
+                 FROM `{bq_project}.cardano_mainnet.withdrawal`
                  WHERE epoch_no = {epoch_no}
                  ORDER BY epoch_no, slot_no, txidx, stake_addr_hash ASC))
             ) AS innerq;""",
-            f"""WITH dat AS
+        f"""WITH dat AS
                 (SELECT epoch_no, stake_addr_hash, amount, slot_no, txidx
                 FROM analytics.vw_bq_withdrawal
                 WHERE epoch_no = {epoch_no})
-                
+
                 SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(regexp_replace(regexp_replace(subq.str, '[\n]', '', 'g'), '[\s]', '', 'g')::bytea),'base64'), ',')::bytea AS hash_b64 FROM
-                 (SELECT 
+                 (SELECT
                     '('|| (epoch_no)
                     ||',' || (stake_addr_hash)
                     ||',' || (amount)
@@ -148,11 +201,14 @@ def query_withdrawal(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                     ||')' AS str
                   FROM dat) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )
 
 
-def query_delegation(epoch_no, bq_project = os.environ['BQ_PROJECT']):
-    return (f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
+def query_delegation(epoch_no, bq_project=os.environ["BQ_PROJECT"]):
+    return (
+        f"""SELECT TO_BASE64(SHA256(innerq.hash_b64)) AS hash_b64 FROM
             (SELECT STRING_AGG(TO_BASE64(SHA256(str)), ',') AS hash_b64 FROM
              (SELECT
                 '('|| (epoch_no)
@@ -161,22 +217,24 @@ def query_delegation(epoch_no, bq_project = os.environ['BQ_PROJECT']):
                 ||')' AS str
               FROM
               (SELECT epoch_no, stake_addr_hash, delegations
-                 FROM `{bq_project}.cardano_mainnet.delegation` 
+                 FROM `{bq_project}.cardano_mainnet.delegation`
                  WHERE epoch_no = {epoch_no}
                  ORDER BY epoch_no, stake_addr_hash ASC))
             ) AS innerq;""",
-            f"""WITH dat AS
+        f"""WITH dat AS
                 (SELECT epoch_no, stake_addr_hash, delegations
                 FROM analytics.vw_bq_delegation
                 WHERE epoch_no = {epoch_no})
-                
+
                 SELECT encode(SHA256(innerq.hash_b64),'base64') AS hash_b64 FROM
                 (SELECT STRING_AGG(encode(SHA256(regexp_replace(regexp_replace(subq.str, '[\n]', '', 'g'), '[\s]', '', 'g')::bytea),'base64'), ',')::bytea AS hash_b64 FROM
-                 (SELECT 
+                 (SELECT
                     '('|| (epoch_no)
                     ||',' || (stake_addr_hash)
                     ||',' || (delegations::text)
                     ||')' AS str
                   FROM dat) AS subq
                 ) AS innerq;""",
-            lambda x: x, lambda x: x)
+        lambda x: x,
+        lambda x: x,
+    )

--- a/scripts/run_update_epoch.sh
+++ b/scripts/run_update_epoch.sh
@@ -31,7 +31,7 @@ gcloud auth activate-service-account $BQUSER --key-file ${TEMPDIR}/key.json
 ${BQ} ls
 
 # use for loop to read all tables
-for TABLE in epoch_param ada_pots param_proposal ma_minting pool_update pool_offline_data delegation reward reward_pool reward_addr rel_addr_txout rel_stake_txout epoch_stake;
+for TABLE in epoch_param ada_pots param_proposal ma_minting pool_update pool_offline_data delegation reward reward_pool reward_addr rel_addr_txout rel_stake_txout epoch_stake epoch_stake_addr epoch_stake_pool;
 do
   TABLENAME="${BQ_PROJECT}.cardano_mainnet.${TABLE}"
   res=$(${BQ} --format=json query --nouse_legacy_sql "SELECT last_epoch_no FROM ${BQ_PROJECT}.db_sync.last_index where tablename = '${TABLENAME}'")

--- a/scripts/run_update_epoch.sh
+++ b/scripts/run_update_epoch.sh
@@ -31,7 +31,7 @@ gcloud auth activate-service-account $BQUSER --key-file ${TEMPDIR}/key.json
 ${BQ} ls
 
 # use for loop to read all tables
-for TABLE in epoch_param ada_pots param_proposal ma_minting pool_update pool_offline_data delegation reward rel_addr_txout rel_stake_txout epoch_stake;
+for TABLE in epoch_param ada_pots param_proposal ma_minting pool_update pool_offline_data delegation reward reward_pool rel_addr_txout rel_stake_txout epoch_stake;
 do
   TABLENAME="${BQ_PROJECT}.cardano_mainnet.${TABLE}"
   res=$(${BQ} --format=json query --nouse_legacy_sql "SELECT last_epoch_no FROM ${BQ_PROJECT}.db_sync.last_index where tablename = '${TABLENAME}'")

--- a/scripts/run_update_epoch.sh
+++ b/scripts/run_update_epoch.sh
@@ -31,7 +31,7 @@ gcloud auth activate-service-account $BQUSER --key-file ${TEMPDIR}/key.json
 ${BQ} ls
 
 # use for loop to read all tables
-for TABLE in epoch_param ada_pots param_proposal ma_minting pool_update pool_offline_data delegation reward reward_pool rel_addr_txout rel_stake_txout epoch_stake;
+for TABLE in epoch_param ada_pots param_proposal ma_minting pool_update pool_offline_data delegation reward reward_pool reward_addr rel_addr_txout rel_stake_txout epoch_stake;
 do
   TABLENAME="${BQ_PROJECT}.cardano_mainnet.${TABLE}"
   res=$(${BQ} --format=json query --nouse_legacy_sql "SELECT last_epoch_no FROM ${BQ_PROJECT}.db_sync.last_index where tablename = '${TABLENAME}'")

--- a/scripts/update_epoch_epoch_stake_addr.sh
+++ b/scripts/update_epoch_epoch_stake_addr.sh
@@ -11,7 +11,7 @@ source ./conf/config.pg
 source ./conf/config.bq
 source functions.sh
 
-TNAME="epoch_stake"
+TNAME="epoch_stake_addr"
 
 BQ_EPOCH_NO=$1
 PG_EPOCH_NO=$2
@@ -33,7 +33,7 @@ if [ -e "${CSVNAME}.csv" ]; then rm -f "${CSVNAME}.csv"; fi
 SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
-## 1 insert epoch into table: tmp_epoch_stake_1
+## 1 insert epoch into table: tmp_epoch_stake_addr_1
 TMPTBL="tmp_epoch_${SCHEMA}_1"
 Q="
   SELECT epoch_no,

--- a/scripts/update_epoch_epoch_stake_pool.sh
+++ b/scripts/update_epoch_epoch_stake_pool.sh
@@ -11,7 +11,7 @@ source ./conf/config.pg
 source ./conf/config.bq
 source functions.sh
 
-TNAME="epoch_stake"
+TNAME="epoch_stake_pool"
 
 BQ_EPOCH_NO=$1
 PG_EPOCH_NO=$2
@@ -33,7 +33,7 @@ if [ -e "${CSVNAME}.csv" ]; then rm -f "${CSVNAME}.csv"; fi
 SCHEMA="${TNAME}"
 DATASETID="${BQ_PROJECT}:db_sync"
 
-## 1 insert epoch into table: tmp_epoch_stake_1
+## 1 insert epoch into table: tmp_epoch_stake_pool_1
 TMPTBL="tmp_epoch_${SCHEMA}_1"
 Q="
   SELECT epoch_no,

--- a/scripts/update_epoch_reward_addr.sh
+++ b/scripts/update_epoch_reward_addr.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 2 ]; then
+	echo "$0 bq_epoch_no pg_epoch_no"
+	exit 1
+fi
+
+set -e
+
+source ./conf/config.pg
+source ./conf/config.bq
+source ./functions.sh
+
+TNAME="reward_addr"
+
+BQ_EPOCH_NO=$1
+PG_EPOCH_NO=$2
+
+if [ "$BQ_EPOCH_NO" -eq "$PG_EPOCH_NO" ]; then
+	echo "Last epoch in BigQuery is $BQ_EPOCH_NO. Nothing to do."
+	exit 1
+elif [ "$BQ_EPOCH_NO" -gt "$PG_EPOCH_NO" ]; then
+  echo "Last epoch in BigQuery is $BQ_EPOCH_NO > $PG_EPOCH_NO (epoch in Postgres)"
+  exit 1
+else 
+  EPOCH_NO=$(( BQ_EPOCH_NO + 1 ))
+  echo "BQ @ ${EPOCH_NO}"
+  echo "   loading for epoch $EPOCH_NO"
+fi
+
+CSVNAME="update_${TNAME}-q1"
+if [ -e "${CSVNAME}.csv" ]; then rm -f "${CSVNAME}.csv"; fi
+SCHEMA="${TNAME}"
+DATASETID="${BQ_PROJECT}:db_sync"
+
+## 1 insert epoch into tmp table
+TMPTBL="tmp_epoch_${TNAME}_1"
+Q="
+  SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
+  FROM analytics.vw_bq_reward
+  WHERE epoch_no = ${EPOCH_NO}"
+  
+NREAD=$(pg_query_to_csv "${Q}" "$CSVNAME")
+if [ -z "${NREAD}" -o $NREAD -lt 0 ]
+then 
+  echo "Q: returned ${NREAD}."; 
+  exit 1;
+elif [ $NREAD -eq 0 ]
+then
+  echo "Q: returned ${NREAD}. Nothing to do"; 
+  exit 0;
+fi
+bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
+
+# run the transaction
+SRCDATASET="${BQ_PROJECT}.db_sync"
+TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
+Q="
+   BEGIN TRANSACTION;
+   -- 1 insert new epoch
+   INSERT INTO ${TARGETTBL}
+   SELECT * FROM ${SRCDATASET}.${TMPTBL};
+   -- 2 update the last index table
+   UPDATE db_sync.last_index set last_epoch_no=${EPOCH_NO} WHERE tablename='${TARGETTBL}';
+   COMMIT TRANSACTION;
+"
+
+#DRYRUN="--dry_run"
+DRYRUN=
+
+${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
+
+echo
+echo "values inserted successfully for epoch: ${EPOCH_NO}"
+echo "all done."

--- a/scripts/update_epoch_reward_pool.sh
+++ b/scripts/update_epoch_reward_pool.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 2 ]; then
+	echo "$0 bq_epoch_no pg_epoch_no"
+	exit 1
+fi
+
+set -e
+
+source ./conf/config.pg
+source ./conf/config.bq
+source ./functions.sh
+
+TNAME="reward_pool"
+
+BQ_EPOCH_NO=$1
+PG_EPOCH_NO=$2
+
+if [ "$BQ_EPOCH_NO" -eq "$PG_EPOCH_NO" ]; then
+	echo "Last epoch in BigQuery is $BQ_EPOCH_NO. Nothing to do."
+	exit 1
+elif [ "$BQ_EPOCH_NO" -gt "$PG_EPOCH_NO" ]; then
+  echo "Last epoch in BigQuery is $BQ_EPOCH_NO > $PG_EPOCH_NO (epoch in Postgres)"
+  exit 1
+else 
+  EPOCH_NO=$(( BQ_EPOCH_NO + 1 ))
+  echo "BQ @ ${EPOCH_NO}"
+  echo "   loading for epoch $EPOCH_NO"
+fi
+
+CSVNAME="update_${TNAME}-q1"
+if [ -e "${CSVNAME}.csv" ]; then rm -f "${CSVNAME}.csv"; fi
+SCHEMA="${TNAME}"
+DATASETID="${BQ_PROJECT}:db_sync"
+
+## 1 insert epoch into tmp table
+TMPTBL="tmp_epoch_${TNAME}_1"
+Q="
+  SELECT epoch_no, stake_addr_hash, type, amount, earned_epoch, pool_hash
+  FROM analytics.vw_bq_reward
+  WHERE epoch_no = ${EPOCH_NO}"
+  
+NREAD=$(pg_query_to_csv "${Q}" "$CSVNAME")
+if [ -z "${NREAD}" -o $NREAD -lt 0 ]
+then 
+  echo "Q: returned ${NREAD}."; 
+  exit 1;
+elif [ $NREAD -eq 0 ]
+then
+  echo "Q: returned ${NREAD}. Nothing to do"; 
+  exit 0;
+fi
+bq_load_csv "$CSVNAME" "$TMPTBL" "$SCHEMA" "$DATASETID"
+
+# run the transaction
+SRCDATASET="${BQ_PROJECT}.db_sync"
+TARGETTBL="${BQ_PROJECT}.cardano_mainnet.${TNAME}"
+Q="
+   BEGIN TRANSACTION;
+   -- 1 insert new epoch
+   INSERT INTO ${TARGETTBL}
+   SELECT * FROM ${SRCDATASET}.${TMPTBL};
+   -- 2 update the last index table
+   UPDATE db_sync.last_index set last_epoch_no=${EPOCH_NO} WHERE tablename='${TARGETTBL}';
+   COMMIT TRANSACTION;
+"
+
+#DRYRUN="--dry_run"
+DRYRUN=
+
+${BQ} query --bigqueryrc=$(pwd)/dot.bigqueryrc ${DRYRUN} --dataset_id=${DATASETID} --nouse_legacy_sql "${Q}" 2> logs/update_${TNAME}-query.err > logs/update_${TNAME}-query.out
+
+echo
+echo "values inserted successfully for epoch: ${EPOCH_NO}"
+echo "all done."


### PR DESCRIPTION
* adds a new table "reward_pool" which contains all rewards (a copy of "reward")
  * clustered by "pool_hash"
This gives lightweight access to rewards related to a pool.

* adds a new table "reward_addr" which contains all rewards (a copy of "reward")
  * clustered by "stake_addr_hash"
This gives lightweight access to rewards related to a staking address.

fixes #34 

* adds new table "epoch_stake_addr" which contains all data from "epoch_stake"
  * clustered by "stake_addr_hash"
This gives lightweight access to staking related to a staking address.

* adds a new table "epoch_stake_pool" which contains all data from "epoch_stake"
  * clustered by "pool_hash"
This gives lightweight access to staking related to a pool.

fixes #33